### PR TITLE
fix: Correct ChatGPT data gathering and resolve pandas warning

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -633,7 +633,10 @@ class TradingPage(ttk.Frame):
             # 1. Gather data
             symbol = self.symbol_var.get().replace("/", "")
             price = self.trader.get_market_price(symbol)
-            ohlc_1m_df = self.trader.ohlc_history.get('1m', pd.DataFrame())
+
+            # Get OHLC data for the selected symbol
+            symbol_ohlc = self.trader.ohlc_history.get(symbol, {})
+            ohlc_1m_df = symbol_ohlc.get('1m', pd.DataFrame())
 
             if price is None or ohlc_1m_df.empty:
                 self.controller._ui_queue.put(("show_ai_error", ("Could not perform analysis: Market data is missing.",)))

--- a/trading.py
+++ b/trading.py
@@ -1022,10 +1022,14 @@ class Trader:
                     }], index=[current_tf_bar['timestamp']])
                     completed_bar_df.index.name = 'timestamp'
 
-                    # Append to history
-                    self.ohlc_history[symbol_name][tf_str] = pd.concat([
-                        self.ohlc_history[symbol_name][tf_str], completed_bar_df
-                    ])
+                    # Append to history, avoiding concat with empty dataframe
+                    history_df = self.ohlc_history[symbol_name][tf_str]
+                    if history_df.empty:
+                        self.ohlc_history[symbol_name][tf_str] = completed_bar_df
+                    else:
+                        self.ohlc_history[symbol_name][tf_str] = pd.concat([
+                            history_df, completed_bar_df
+                        ])
 
                     # Trim history
                     history_df = self.ohlc_history[symbol_name][tf_str]


### PR DESCRIPTION
This commit addresses two bugs:

1.  Fixes the `_chatgpt_analysis_thread` in `gui.py` to correctly retrieve OHLC data from the multi-symbol `ohlc_history` dictionary. This resolves the "Market data is missing" error.
2.  Fixes a `FutureWarning` in `_handle_spot_event` in `trading.py` by checking if the OHLC history DataFrame is empty before using `pd.concat`, preventing a warning on the creation of the first bar.