### PR TITLE
feat: Add configurable trading hours and fix GUI layout

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -180,14 +180,27 @@ class SettingsPage(ttk.Frame):
         ttk.Label(acct, text="Margin Level:").grid(row=5, column=0, sticky="w", padx=(0,5))
         ttk.Label(acct, textvariable=self.margin_level_var).grid(row=5, column=1, sticky="w")
 
+        # --- Trading Hours ---
+        hours_frame = ttk.Labelframe(self, text="Trading Hours (Safe Strategy)", padding=10)
+        hours_frame.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(0, 10))
+        hours_frame.columnconfigure(1, weight=1)
+
+        self.start_hour_var = tk.StringVar(value=str(self.controller.settings.general.trading_start_hour))
+        ttk.Label(hours_frame, text="Start Hour (0-23):").grid(row=0, column=0, sticky="w", padx=(0,5))
+        ttk.Entry(hours_frame, textvariable=self.start_hour_var).grid(row=0, column=1, sticky="ew")
+
+        self.end_hour_var = tk.StringVar(value=str(self.controller.settings.general.trading_end_hour))
+        ttk.Label(hours_frame, text="End Hour (1-24):").grid(row=1, column=0, sticky="w", padx=(0,5))
+        ttk.Entry(hours_frame, textvariable=self.end_hour_var).grid(row=1, column=1, sticky="ew")
+
         # --- Actions & Status ---
         actions = ttk.Frame(self)
-        actions.grid(row=2, column=0, columnspan=2, sticky="ew", pady=(10,0))
+        actions.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(10,0))
         ttk.Button(actions, text="Save Settings", command=self.save_settings).pack(side="left", padx=5)
         ttk.Button(actions, text="Connect", command=self.attempt_connection).pack(side="left", padx=5)
 
         self.status = ttk.Label(self, text="Disconnected", anchor="center")
-        self.status.grid(row=3, column=0, columnspan=2, sticky="ew", pady=(5,0))
+        self.status.grid(row=4, column=0, columnspan=2, sticky="ew", pady=(5,0))
 
     def update_account_info(self, account_id: str, balance: float | None, equity: float | None, used_margin: float | None, free_margin: float | None, margin_level: float | None):
         """Public method to update account info StringVars."""
@@ -206,6 +219,14 @@ class SettingsPage(ttk.Frame):
             self.controller.settings.openapi.default_ctid_trader_account_id = int(self.account_id_entry_var.get())
         except (ValueError, TypeError):
             self.controller.settings.openapi.default_ctid_trader_account_id = None
+
+        try:
+            self.controller.settings.general.trading_start_hour = int(self.start_hour_var.get())
+            self.controller.settings.general.trading_end_hour = int(self.end_hour_var.get())
+        except (ValueError, TypeError):
+            messagebox.showerror("Invalid Input", "Trading hours must be integers.")
+            return
+
         self.controller.settings.save()
         messagebox.showinfo("Settings Saved", "Your settings have been saved successfully.")
 
@@ -348,10 +369,9 @@ class TradingPage(ttk.Frame):
         self.equity_var_tp = tk.StringVar(value="–")
 
         # configure grid
-        # Adjusted row count for new account info section AND data readiness label
-        for r in range(13): # Increased range for new row + data readiness
+        for r in range(14): # Set non-expanding rows
             self.rowconfigure(r, weight=0)
-        self.rowconfigure(13, weight=1) # Adjusted log row index
+        self.rowconfigure(14, weight=1) # Make the output log row expandable
         self.columnconfigure(1, weight=1)
 
 

--- a/settings.py
+++ b/settings.py
@@ -31,7 +31,8 @@ class GeneralSettings:
     min_bars_for_trading: int = 50
     risk_percentage: float = 1.0
     batch_profit_target: float = 10.0
-    # Add other general app settings here if any
+    trading_start_hour: int = 0
+    trading_end_hour: int = 24
 
 @dataclass
 class AISettings:
@@ -93,7 +94,9 @@ class Settings:
             chart_update_interval_ms=general_cfg.get("chart_update_interval_ms", 500),
             min_bars_for_trading=general_cfg.get("min_bars_for_trading", 50),
             risk_percentage=general_cfg.get("risk_percentage", 1.0),
-            batch_profit_target=general_cfg.get("batch_profit_target", 10.0)
+            batch_profit_target=general_cfg.get("batch_profit_target", 10.0),
+            trading_start_hour=general_cfg.get("trading_start_hour", 0),
+            trading_end_hour=general_cfg.get("trading_end_hour", 24)
         )
 
         ai_settings = AISettings(
@@ -134,6 +137,8 @@ class Settings:
                 "min_bars_for_trading": self.general.min_bars_for_trading,
                 "risk_percentage": self.general.risk_percentage,
                 "batch_profit_target": self.general.batch_profit_target,
+                "trading_start_hour": self.general.trading_start_hour,
+                "trading_end_hour": self.general.trading_end_hour,
             },
             "ai": {
                 "use_ai_overseer": self.ai.use_ai_overseer,

--- a/strategies.py
+++ b/strategies.py
@@ -49,8 +49,6 @@ class SafeStrategy(Strategy):
         target_mult: float = 0.5,
         buffer_mult: float = 0.05,  # changed from 0.2 to allow more trades; adjust as needed
         volume_mult: float = 1.5,
-        session_start: time = time(6, 0),
-        session_end: time = time(18, 0),
         session_tz: str = "Europe/London",
     ):
         # Trend & volatility settings
@@ -63,8 +61,10 @@ class SafeStrategy(Strategy):
         self.volume_mult = volume_mult
 
         # Trading session window
-        self.session_start = session_start
-        self.session_end = session_end
+        start_h = self.settings.general.trading_start_hour
+        end_h = self.settings.general.trading_end_hour
+        self.session_start = time(start_h, 0)
+        self.session_end = time(end_h, 0) if end_h < 24 else time(23, 59, 59)
         self.session_zone = ZoneInfo(session_tz)
 
         # Trailing stop state


### PR DESCRIPTION
This commit introduces two main improvements based on user feedback:

1.  Adds a setting for configurable trading hours (`trading_start_hour`, `trading_end_hour`). The `SafeStrategy` now uses these settings to determine if it is within the allowed trading session, removing the previous hardcoded values. The settings can be edited on the Settings page.
2.  Fixes two GUI layout bugs: an overlapping widget on the Settings page and an incorrect row-resize weight on the Trading page. These changes prevent UI distortion.