### PR TITLE
fix: Correct GUI layout and add margin debug code

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -374,7 +374,12 @@ class TradingPage(ttk.Frame):
             lambda e: canvas.configure(scrollregion=canvas.bbox("all"))
         )
 
-        canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+        canvas_window = canvas.create_window((0, 0), window=scrollable_frame, anchor="nw")
+
+        def on_canvas_configure(event):
+            canvas.itemconfig(canvas_window, width=event.width)
+
+        canvas.bind("<Configure>", on_canvas_configure)
         canvas.configure(yscrollcommand=scrollbar.set)
 
         canvas.grid(row=0, column=0, sticky="nsew")

--- a/trading.py
+++ b/trading.py
@@ -782,7 +782,7 @@ class Trader:
         """Helper to update trader balance and equity from a ProtoOATrader object."""
         print(log_message)
         if trader_proto:
-            print(f"Full ProtoOATrader object received in _update_trader_details: {trader_proto}")
+            print(f"DEBUG: Raw trader_proto object received:\n{trader_proto}\n")
 
             # Safely get ctidTraderAccountId for logging, though it's not set here directly
             logged_ctid = getattr(trader_proto, 'ctidTraderAccountId', 'N/A')


### PR DESCRIPTION
This commit addresses two issues from user feedback:

1.  Corrects the layout of the scrollable TradingPage by adding a binding to the canvas's `<Configure>` event. This ensures the content frame resizes horizontally with the window, eliminating empty space.
2.  Adds a temporary debug print statement to `_update_trader_details` to log the raw `ProtoOATrader` object. This is a temporary measure to diagnose why margin information is not displaying correctly.