### PR TITLE
feat: Add detailed logging to place_market_order

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -1916,12 +1916,13 @@ class Trader:
         if client_msg_id:
             req.clientOrderId = client_msg_id
 
+        print(f"DEBUG: Sending ProtoOANewOrderReq:\n{req}")
         try:
             deferred = self._client.send(req)
             # Add callbacks for logging the result of the send operation
             deferred.addCallbacks(
-                lambda response: print(f"Order request sent successfully. Server Response: {response}"),
-                lambda failure: print(f"Failed to send order request. Failure: {failure}")
+                lambda response: print(f"DEBUG: Order request successful. Full Server Response:\n{response}"),
+                lambda failure: print(f"DEBUG: Failed to send order request. Full Failure object:\n{failure}")
             )
             return True, f"Order request for {volume_in_units} units ({volume_lots} lots) of {symbol_name} sent."
         except Exception as e:


### PR DESCRIPTION
This commit enhances the logging in the `place_market_order` method to help diagnose why trade execution events are not being processed. It now prints the full request message and the full response/failure from the server callback.