### PR TITLE
fix: Handle ProtoOAOrderErrorEvent to display trade rejections

### DIFF
--- a/gui.py
+++ b/gui.py
@@ -29,7 +29,8 @@ class MainApplication(ThemedTk):
         self.trader = Trader(
             self.settings,
             on_account_update=self._handle_account_update,
-            on_positions_update=self._handle_positions_update
+            on_positions_update=self._handle_positions_update,
+            on_log_message=self._handle_log_message
         )
         self.after(100, self._process_ui_queue)
 
@@ -84,6 +85,10 @@ class MainApplication(ThemedTk):
     def _handle_positions_update(self, positions: Dict[int, Any]):
         """Callback for the Trader to push position updates."""
         self._ui_queue.put(("positions_update", positions))
+
+    def _handle_log_message(self, message: str):
+        """Callback for the Trader to push log messages."""
+        self._ui_queue.put(("_log", message))
 
     def _process_ui_queue(self):
         """Process items from the UI queue."""


### PR DESCRIPTION
This commit adds a new callback `on_log_message` to the Trader class and wires it up in the MainApplication to allow the backend to send log messages to the UI.

It then implements a handler for the `ProtoOAOrderErrorEvent` in `_on_message_received`. When the broker rejects an order, the error code and description are now formatted and displayed in the application's log window, making it clear to the user why the trade failed.

## Summary by Sourcery

Introduce a log message callback to relay backend events to the UI and display broker order rejections in the application log.

Enhancements:
- Add an on_log_message callback to the Trader and wire it up in the GUI.
- Handle ProtoOAOrderErrorEvent in _on_message_received to format and push order rejection details to the UI log.