### PR TITLE
fix: Correct trade tracking and GUI layout, add features

### DIFF
--- a/trading.py
+++ b/trading.py
@@ -1116,33 +1116,27 @@ class Trader:
         return sorted(list(self.symbols_map.keys()))
 
     def _handle_execution_event(self, event: ProtoOAExecutionEvent) -> None:
-        """Handles execution events to track open positions."""
-        print(f"\n--- Handling Execution Event ---\nRaw Event: {event}\n---------------------------------")
-
+        """Handles execution events to track open positions by focusing on the position object."""
         position_data = event.position
         order_data = event.order
 
+        # An execution event must have position data with a valid ID to be trackable.
         if not hasattr(position_data, 'positionId') or not position_data.positionId:
-            print("DEBUG: Event does not have a positionId. Skipping.")
-            return  # Not an event related to a specific position
+            return
 
         position_id = position_data.positionId
-        print(f"DEBUG: Processing event for positionId: {position_id}")
         status = position_data.positionStatus
 
-        # Position is opened or modified
         if status == ProtoOAPositionStatus.POSITION_STATUS_OPEN:
-            print(f"DEBUG: Position {position_id} is OPEN.")
             symbol_name = self.symbol_id_to_name_map.get(position_data.symbolId)
             if not symbol_name:
-                print(f"DEBUG: Execution event for unknown symbol ID {position_data.symbolId}. Cannot track position.")
+                print(f"Warning: Execution event for unknown symbol ID {position_data.symbolId}")
                 return
 
             symbol_details = self.symbol_details_map.get(position_data.symbolId)
             if not symbol_details or not symbol_details.lotSize:
-                print(f"DEBUG: Cannot process execution event: missing details for symbol {symbol_name}. Requesting details.")
-                # Request details and hope for the best next time
                 self._send_get_symbol_details_request([position_data.symbolId])
+                print(f"Warning: Missing details for symbol {symbol_name}, cannot track position yet. Requesting details.")
                 return
 
             volume_in_lots = position_data.tradeData.volume / symbol_details.lotSize
@@ -1153,24 +1147,16 @@ class Trader:
                 trade_side=ProtoOATradeSide.Name(position_data.tradeData.tradeSide),
                 volume_lots=volume_in_lots,
                 open_price=position_data.price,
-                open_timestamp=order_data.executionTimestamp
+                open_timestamp=order_data.executionTimestamp if order_data else position_data.utcLastUpdateTimestamp
             )
             self.open_positions[position_id] = new_pos
-            print(f"DEBUG: Position {position_id} added/updated in tracked list. Total tracked positions: {len(self.open_positions)}")
-            # Ensure we are subscribed to this symbol for P&L updates
+            print(f"Position opened/updated: {new_pos}")
             self.handle_symbol_selection(symbol_name)
 
-        # Position is closed
         elif status == ProtoOAPositionStatus.POSITION_STATUS_CLOSED:
-            print(f"DEBUG: Position {position_id} is CLOSED.")
             if position_id in self.open_positions:
                 closed_pos = self.open_positions.pop(position_id)
-                print(f"DEBUG: Position {position_id} removed from tracking. Total tracked positions: {len(self.open_positions)}")
-            else:
-                # This can happen if the position was opened before the app started
-                print(f"DEBUG: Received close event for untracked position ID: {position_id}")
-        else:
-            print(f"DEBUG: Position {position_id} has unhandled status: {ProtoOAPositionStatus.Name(status)}")
+                print(f"Position closed: {closed_pos}")
 
     def _handle_send_error(self, failure: Any) -> None:
         print(f"Send error: {failure.getErrorMessage()}")


### PR DESCRIPTION
This commit provides a comprehensive set of fixes and features:

- Refactors `_handle_execution_event` to robustly track open positions from all relevant server messages, fixing the bug where trades did not appear in the UI.
- Implements the `close_all_positions` function.
- Makes the `TradingPage` scrollable and fixes horizontal resizing to resolve layout distortions.
- Adds configurable trading hours to the settings and integrates them into the `SafeStrategy`.
- Implements a handler for `ProtoOAOrderErrorEvent` to display trade rejection messages in the log.